### PR TITLE
Fix `get-bounds` method

### DIFF
--- a/source/browser-view.lisp
+++ b/source/browser-view.lisp
@@ -18,11 +18,14 @@
    (format nil "~a.setBounds({x: ~a, y: ~a, width: ~a, height: ~a})"
            (remote-symbol browser-view) x y width height)))
 
-(defmethod get-bounds ((browser-view browser-view))
+(defmethod get-bounds ((browser-view browser-view) parameter)
+  "Return Rectangle Object's PARAMETER of BROWSER-VIEW.
+See `set-bounds' for the list of available parameters."
   (let ((new-id (new-id)))
     (send-message
      browser-view
-     (format nil "~a = ~a.getBounds()" new-id (remote-symbol browser-view)))))
+     (format nil "~a = ~a.getBounds().~(~a~)"
+             new-id (remote-symbol browser-view) parameter))))
 
 (defmethod set-auto-resize ((browser-view browser-view)
                             width

--- a/source/browser-window.lisp
+++ b/source/browser-window.lisp
@@ -82,11 +82,14 @@
    browser-window
    (format nil "~a.focus()" (remote-symbol browser-window))))
 
-(defmethod get-bounds ((browser-window browser-window))
+(defmethod get-bounds ((browser-window browser-window) parameter)
+  "Return Rectangle Object's PARAMETER of BROWSER-WINDOW.
+See `set-bounds' for the list of available parameters."
   (let ((new-id (new-id)))
     (send-message
      browser-window
-     (format nil "~a = ~a.getBounds()" new-id (remote-symbol browser-window)))))
+     (format nil "~a = ~a.getBounds().~(~a~)"
+             new-id (remote-symbol browser-window) parameter))))
 
 (defmethod set-bounds ((browser-window browser-window) x y width height)
   (send-message


### PR DESCRIPTION
Closes #13.

The parameter may be passed as a symbol or as a string.

```lisp
ELECTRON> (electron::get-bounds win 'height)
"333"
NIL
ELECTRON> (electron::get-bounds win "height")
"333"
NIL
```