### PR TITLE
Socket per channel

### DIFF
--- a/demos/demo-protocol.lisp
+++ b/demos/demo-protocol.lisp
@@ -18,8 +18,6 @@
                              :scheme-name "noplay"
                              :privileges "{stream:true}")))
   (electron:launch electron:*interface*)
-  ;; See https://github.com/atlas-engineer/cl-electron/issues/15
-  (sleep 1)
   (electron:handle (find "noplay" (electron:protocols electron:*interface*)
                          :key #'electron:scheme-name :test #'string-equal)
                    "() => {return net.fetch('https://www.learningcontainer.com/wp-content/uploads/2020/02/Kalimba.mp3')}")

--- a/demos/demo-views.lisp
+++ b/demos/demo-views.lisp
@@ -75,8 +75,6 @@
 (defun electron-views-demo ()
  (setf electron:*interface* (make-instance 'electron:interface))
   (electron:launch)
-  ;; See https://github.com/atlas-engineer/cl-electron/issues/15
-  (sleep 1)
   (let ((win (make-instance 'electron:browser-window :options "{frame: false}")))
     (values (make-instance 'main-view :parent-window win)
             (make-instance 'modeline :parent-window win)

--- a/demos/demo-window.lisp
+++ b/demos/demo-window.lisp
@@ -7,10 +7,8 @@
 (in-package :electron/demo)
 
 (defun electron-window-demo ()
- (setf electron:*interface* (make-instance 'electron:interface))
+  (setf electron:*interface* (make-instance 'electron:interface))
   (electron:launch)
-  ;; See https://github.com/atlas-engineer/cl-electron/issues/15
-  (sleep 1)
   (let ((win (make-instance 'electron:browser-window)))
     (electron:load-url win "https://en.wikipedia.org/wiki/Electron")
     (electron::register-before-input-event win

--- a/source/core.lisp
+++ b/source/core.lisp
@@ -84,7 +84,10 @@ required to be registered there."))
                                  ,@(mapcar #'uiop:native-namestring
                                            (list (server-path interface)
                                                  (electron-socket-path interface))))
-                               :output :interactive))))
+                               :output :interactive))
+    ;; Block until the socket is ready and responding with evaluated code.
+    (loop for probe = (ignore-errors (send-message-interface interface "0"))
+          until (equalp "0" probe))))
 
 (defun create-socket-path (&key (prefix "cl-electron") (id (new-integer-id)))
   "Generate a new path suitable for a socket."

--- a/source/core.lisp
+++ b/source/core.lisp
@@ -8,7 +8,7 @@
 
 (define-class interface ()
   ((electron-socket-path
-    (uiop:xdg-runtime-dir "electron.socket")
+    (uiop:xdg-runtime-dir "cl-electron.socket")
     :export t
     :documentation "The Electron process listens to this sockets to execute
 JavaScript.

--- a/source/core.lisp
+++ b/source/core.lisp
@@ -139,6 +139,7 @@ required to be registered there."))
 (export-always 'terminate)
 (defun terminate (&optional (interface *interface*))
   (when (and (process interface) (uiop:process-alive-p (process interface)))
+    (mapcar #'bt:destroy-thread (alexandria:hash-table-values (socket-threads interface)))
     (uiop:terminate-process (process interface))
     (setf (process interface) nil)))
 

--- a/source/protocol.lisp
+++ b/source/protocol.lisp
@@ -31,21 +31,12 @@
     return new Promise((resolve, reject) => {
         jsonString = JSON.stringify([ request.url ]);
         ~a.write(`${jsonString}\\n`);
-        let message_buffer = '';
-        ~a.on('data', data => {
-            let data_string = data.toString();
-            let transmission_end_index = data_string.indexOf('');
-            if (transmission_end_index == -1) {
-                message_buffer += data_string;
-            } else {
-                message_buffer += data_string.substring(0, transmission_end_index);
-                const jsonObject = JSON.parse(message_buffer);
-                message_buffer = data_string.substring(transmission_end_index + 1, data_string.length)
-                const newResponse = new Response(jsonObject.dataString, {
-                   headers: { 'content-type': jsonObject.dataType }
-                });
-                resolve(newResponse);
-            }
+        new ProtocolSocket(~a, data => {
+            const jsonObject = JSON.parse(data);
+            const newResponse = new Response(jsonObject.dataString, {
+                headers: { 'content-type': jsonObject.dataType }
+            });
+            resolve(newResponse);
         });
     });
 }" socket-thread-id socket-thread-id))))

--- a/source/protocol.lisp
+++ b/source/protocol.lisp
@@ -18,22 +18,21 @@
 
 (export-always 'handle-callback)
 (defmethod handle-callback ((protocol protocol) callback)
-  (let ((identifier (new-integer-id)))
-    (setf (gethash identifier (callbacks electron:*interface*))
-          (lambda (args)
+  (let ((socket-thread-id
+          (create-node-socket-thread
+           (lambda (args)
             (cl-json:encode-json-to-string
-             `((callback . ,identifier)
-               ,@(multiple-value-bind (data-string data-type) (apply callback args)
-                   (list `(data-string . ,data-string)
-                         `(data-type . ,(or data-type "text/html;charset=utf8"))))))))
+             (multiple-value-bind (data-string data-type) (apply callback args)
+               (list (cons "dataString" data-string)
+                     (cons "dataType" (or data-type "text/html;charset=utf8")))))))))
     (handle protocol
             (format nil
-"(request) => {
+ "(request) => {
     return new Promise((resolve, reject) => {
-        jsonString = JSON.stringify({ callback: ~a, request: request.url });
-        client.write(`${jsonString}\\n`);
+        jsonString = JSON.stringify([ request.url ]);
+        ~a.write(`${jsonString}\\n`);
         let message_buffer = '';
-        client.on('data', data => {
+        ~a.on('data', data => {
             let data_string = data.toString();
             let transmission_end_index = data_string.indexOf('');
             if (transmission_end_index == -1) {
@@ -42,13 +41,11 @@
                 message_buffer += data_string.substring(0, transmission_end_index);
                 const jsonObject = JSON.parse(message_buffer);
                 message_buffer = data_string.substring(transmission_end_index + 1, data_string.length)
-                if (jsonObject.callback == ~a) {
-                   const newResponse = new Response(jsonObject.dataString, {
-                     headers: { 'content-type': jsonObject.dataType }
-                   });
-                   resolve(newResponse);
-                }
+                const newResponse = new Response(jsonObject.dataString, {
+                   headers: { 'content-type': jsonObject.dataType }
+                });
+                resolve(newResponse);
             }
         });
     });
-}" identifier identifier))))
+}" socket-thread-id socket-thread-id))))

--- a/source/server.js
+++ b/source/server.js
@@ -25,3 +25,27 @@ const server = nodejs_net.createServer((socket) => {
     });
 });
 server.listen(process.argv[2]);
+
+////////////////////////////////////////////////////////////////////////////////
+// Handle long messages from a socket and combine them into a single message. //
+////////////////////////////////////////////////////////////////////////////////
+
+class ProtocolSocket {
+    constructor(socket, onDataFunction) {
+        this.socket = socket;
+        this.onDataFunction = onDataFunction;
+        this.messageBuffer = '';
+
+        this.socket.on('data', data => {
+            let dataString = data.toString();
+            let transmissionEndIndex = dataString.indexOf('');
+            if (transmissionEndIndex == -1) {
+                this.messageBuffer += dataString;
+            } else {
+                this.messageBuffer += dataString.substring(0, transmissionEndIndex);
+                this.onDataFunction(this.messageBuffer);
+                this.messageBuffer = dataString.substring(transmissionEndIndex + 1, dataString.length);
+            }
+        });
+    }
+}

--- a/source/server.js
+++ b/source/server.js
@@ -5,19 +5,15 @@
 // Start a Javascript server that will eval code received. //
 /////////////////////////////////////////////////////////////
 
-if (process.argv.length != 4) {
-  console.error('Requires server and client socket paths.');
+if (process.argv.length != 3) {
+  console.error('Requires server socket path.');
   process.exit(1);
 }
 
 const { app, ipcMain, BrowserView, BrowserWindow, webContents, protocol, net } = require('electron')
 const path = require('path')
 const nodejs_net = require('net');
-client = new nodejs_net.Socket();
 
-////////////
-// Server //
-////////////
 const server = nodejs_net.createServer((socket) => {
     socket.on('data', (data) => {
         try {
@@ -29,10 +25,3 @@ const server = nodejs_net.createServer((socket) => {
     });
 });
 server.listen(process.argv[2]);
-
-////////////
-// Client //
-////////////
-client.connect(process.argv[3], () => {
-    client.setNoDelay(true);
-});


### PR DESCRIPTION
Includes fixes:

1. Block on launch until Electron is ready.
2. Block socket creation on Electron side until Lisp is ready.
3. Use a separate socket per object instance/event type.
4. Handle long messages via the ProtocolSocket class.
5. Add functionality to dynamically create sockets between Lisp/Electron.

Fixes issue #22.

Will *not* fix issue #15.