### PR TITLE
Js synchronous error handling

### DIFF
--- a/cl-electron.asd
+++ b/cl-electron.asd
@@ -22,6 +22,7 @@
   :components ((:module "source"
                 :components
                 ((:file "package")
+                 (:file "condition" :depends-on ("package"))
                  (:file "core" :depends-on ("package"))
                  (:file "browser-window" :depends-on ("package" "core"))
                  (:file "browser-view" :depends-on ("package" "core"))

--- a/source/condition.lisp
+++ b/source/condition.lisp
@@ -1,0 +1,9 @@
+;;;; SPDX-FileCopyrightText: Atlas Engineer LLC
+;;;; SPDX-License-Identifier: BSD-3-Clause
+
+(in-package :electron)
+
+(export-always 'javascript-renderer-error)
+(define-condition javascript-renderer-error (error)
+  ((code :initarg :code :initform nil :reader code))
+  (:documentation "A condition for JavaScript errors within the renderer view."))

--- a/source/web-contents.lisp
+++ b/source/web-contents.lisp
@@ -207,9 +207,11 @@
     (send-message-interface
      (interface web-contents)
      (format nil "~a.executeJavaScript(\"~a\", ~a).then((value) => {
-                   jsonString = JSON.stringify([ value ]);
-                   ~a.write(`${jsonString}\\n`);})"
-             (remote-symbol web-contents) (%quote-js code) user-gesture socket-thread-id))))
+                     jsonString = JSON.stringify([ value ]);
+                     ~a.write(`${jsonString}\\n`);}).catch(error => {
+                       ~a.write('[\"ERROR\"]\\n');});"
+             (remote-symbol web-contents) (%quote-js code)
+             user-gesture socket-thread-id socket-thread-id))))
 
 (export-always 'on)
 (defmethod on ((web-contents web-contents) event-name code)

--- a/source/web-contents.lisp
+++ b/source/web-contents.lisp
@@ -240,6 +240,8 @@
      code
      (lambda (web-contents result)
        (declare (ignore web-contents))
-       (lparallel:fulfill p result))
+       (if (equal result "ERROR")
+           (cerror "Ignore JS error." (make-condition 'javascript-renderer-error :code code))
+           (lparallel:fulfill p result)))
      :user-gesture user-gesture)
     (lparallel:force p)))


### PR DESCRIPTION
Fixes #30 

The current draft doesn't fix the issue.

The error is raised, the user ignores it via the debugger but it is still a blocking operation.