### PR TITLE
core(launch): Simplify existing socket logic.

### DIFF
--- a/source/core.lisp
+++ b/source/core.lisp
@@ -97,28 +97,26 @@ required to be registered there.")
 
 (export-always 'launch)
 (defun launch (&optional (interface *interface*))
-  (when (alive-p interface)
-    (restart-case (error (make-condition 'duplicate-interface-error))
-      (kill ()
-        :report "Kill the existing interface and start a new one."
-        (terminate interface))
-      (ignore ()
-        :report "Ignore the existing interface and launch a new one."
-        nil)))
-  (when (uiop:file-exists-p (electron-socket-path interface))
-    (restart-case (error (make-condition 'socket-exists-error))
-      (destroy ()
-        :report "Destroy the existing socket."
-        (uiop:delete-file-if-exists (electron-socket-path interface)))))
-  (setf (process interface)
-        (uiop:launch-program `("electron"
-                               ,@(mapcar #'uiop:native-namestring
-                                         (list (server-path interface)
-                                               (electron-socket-path interface))))
-                             :output :interactive))
-  ;; Block until the socket is ready and responding with evaluated code.
-  (loop for probe = (ignore-errors (message interface "0"))
-        until (equalp "0" probe)))
+  (cond ((alive-p interface)
+         (restart-case (error (make-condition 'duplicate-interface-error))
+           (kill ()
+             :report "Kill the existing interface and start a new one."
+             (terminate interface))))
+        (t
+         (when (uiop:file-exists-p (electron-socket-path interface))
+           (restart-case (error (make-condition 'socket-exists-error))
+             (destroy ()
+               :report "Destroy the existing socket."
+               (uiop:delete-file-if-exists (electron-socket-path interface)))))
+         (setf (process interface)
+               (uiop:launch-program `("electron"
+                                      ,@(mapcar #'uiop:native-namestring
+                                                (list (server-path interface)
+                                                      (electron-socket-path interface))))
+                                    :output :interactive))
+         ;; Block until the socket is ready and responding with evaluated code.
+         (loop for probe = (ignore-errors (message interface "0"))
+               until (equalp "0" probe)))))
 
 (defun create-socket-path (&key (prefix "cl-electron") (id (new-integer-id)))
   "Generate a new path suitable for a socket."
@@ -202,6 +200,7 @@ required to be registered there.")
 (defun terminate (&optional (interface *interface*))
   (when (and (process interface) (uiop:process-alive-p (process interface)))
     (mapcar #'bt:destroy-thread (socket-threads interface))
+    (uiop:delete-file-if-exists (electron-socket-path interface))
     (uiop:terminate-process (process interface))
     (setf (process interface) nil)))
 


### PR DESCRIPTION
Commit adba6d2009d76acbeacf013cd3370f5c50b355e7 introduced a restart for the case when the socket already exists, but I don't think this is a good idea. Firstly, it harms the tests since a condition is raised on each round-trip of `with-electron-session`. Secondly, under which circumstances would we want not to delete a dangling socket? Only when there would be multiple Electron processes launched by `launch`... But they would be sharing the same socket, which doesn't seem correct. Before, there was the guarantee that only one Electron process could be spawned. Now, there's no such limitation. Why would we want to pursue this strategy? Besides the commit I've pushed to this PR, I'd suggest getting rid of the `ignore` restart and `launch-process` unless `alive-p` (as before), as to guarantee that only one process is spawned. 

As an alternative to the approach described above, `(uiop:delete-file-if-exists (electron-socket-path interface))` should run on `terminate`.

---------

On a tangent, (1) this change was orthogonal to PR #34; (2) a proper review should have taken place; (3) the tests weren't probably run before merging #34. 