### PR TITLE
view.lisp: Properly handle view deletion.

### DIFF
--- a/source/view.lisp
+++ b/source/view.lisp
@@ -53,7 +53,8 @@
 
 (export-always 'kill)
 (defmethod kill ((view view))
-  (kill (web-contents view)))
+  (kill (web-contents view))
+  (setf (slot-value view 'web-contents) nil))
 
 (export-always 'focus)
 (defmethod focus ((view view))

--- a/source/window.lisp
+++ b/source/window.lisp
@@ -176,7 +176,7 @@ of WINDOW's views is reset such that VIEW is shown as the topmost."
    (format nil "~a.contentView.removeChildView(~a)"
            (remote-symbol window)
            (remote-symbol view)))
-  (when kill-view-p (kill (web-contents view))))
+  (when kill-view-p (kill view)))
 
 (export-always 'web-contents)
 (defmethod web-contents ((window window))


### PR DESCRIPTION
This allows us to recreate the WebContentsView for any given view at any arbitrary point in time.