### PR TITLE
Support utf8 callback strings

### DIFF
--- a/cl-electron.asd
+++ b/cl-electron.asd
@@ -19,7 +19,8 @@
                nclasses
                bordeaux-threads
                lparallel
-               parse-number)
+               parse-number
+               babel)
   :components ((:module "source"
                 :components
                 ((:file "package")

--- a/examples/example-protocol.lisp
+++ b/examples/example-protocol.lisp
@@ -21,3 +21,22 @@
     (electron:set-bounds view2 :x 0 :y 200 :width 400 :height 200)
     (electron:load-url view1 "test:dummy-var")
     (electron:load-url view2 "test:dummy-var")))
+
+(defun electron-protocol-example-callback ()
+  (setf (electron:protocols electron:*interface*)
+        (list (make-instance 'electron:protocol
+                             :scheme-name "test"
+                             :privileges "{}")))
+  (electron:launch electron:*interface*)
+  (electron:handle-callback (find "test" (electron:protocols electron:*interface*)
+                                  :key #'electron:scheme-name :test #'string-equal)
+                            (lambda (xyz) (print xyz) "Text with UTF-8 ✈ encoding."))
+  (let ((win (make-instance 'electron:window))
+        (view1 (make-instance 'electron:view))
+        (view2 (make-instance 'electron:view)))
+    (electron:add-view win view1)
+    (electron:add-view win view2)
+    (electron:set-bounds view1 :x 0 :y 0   :width 400 :height 200)
+    (electron:set-bounds view2 :x 0 :y 200 :width 400 :height 200)
+    (electron:load-url view1 "test:dummy-var")
+    (electron:load-url view2 "test:dummy-var")))

--- a/source/protocol.lisp
+++ b/source/protocol.lisp
@@ -16,6 +16,10 @@
 (defmethod handle-content ((protocol protocol) content)
   (handle protocol (format nil "() => {return new Response('~a')}" content)))
 
+(defun base64-encode-utf8 (input-string)
+  (let ((utf8-bytes (babel:string-to-octets input-string)))
+    (cl-base64:usb8-array-to-base64-string utf8-bytes)))
+
 (export-always 'handle-callback)
 (defmethod handle-callback ((protocol protocol) callback)
   (let ((socket-thread-id
@@ -28,7 +32,7 @@
                               ((simple-array (unsigned-byte 8))
                                (cl-base64:usb8-array-to-base64-string data-string))
                               (string
-                               (cl-base64:string-to-base64-string data-string))
+                               (base64-encode-utf8 data-string))
                               (null "")))
                       (cons "dataType" (or data-type "text/html;charset=utf8"))))))
            :interface (interface protocol))))


### PR DESCRIPTION
This fixes the rendering of UTF8 Strings within Nyxt.