### PR TITLE
Add method for overriding default window open behavior

### DIFF
--- a/source/web-contents.lisp
+++ b/source/web-contents.lisp
@@ -196,6 +196,21 @@
                              :remote-symbol new-id
                              :interface (interface web-contents))))))
 
+(export-always 'override-window-open-handler)
+(defmethod override-window-open-handler ((web-contents web-contents) callback)
+  (let ((thread-id (create-node-socket-thread (lambda (response)
+						(funcall callback response)
+						(destroy-thread* (bt:current-thread)))
+					      :interface (interface web-contents))))
+    (message
+     web-contents
+     (format nil "~a.setWindowOpenHandler((details) => {
+                    ~a.write(JSON.stringify(details) + '\\\n');
+                    return { action: 'deny' };
+                  });"
+	     (remote-symbol web-contents)
+	     thread-id))))
+
 (defun %quote-js (js-code)
   "Replace each backslash with 2 (unless a \" follows it) and escape backquotes."
   (ppcre:regex-replace-all "`"


### PR DESCRIPTION
This adds the method `override-window-open-handler`, which takes a callback that is ran when a new window is created from electron. It also defaults to denying the default electron behavior, which is to open a new window from electron.

See https://github.com/atlas-engineer/nyxt/pull/3605